### PR TITLE
fix: remove unused package: leader-line

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "leader-line": "^1.0.7",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "sweetalert2": "^11.4.8",
@@ -4834,11 +4833,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/leader-line": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/leader-line/-/leader-line-1.0.7.tgz",
-      "integrity": "sha512-PhJpQLV7XychSIuGPD0TEqR9PgRYBbrhReaOcmHFOVtTw4dWKfUMAtOb7UP7xTsoib6sFzq2giQeOUHy7LCuJQ=="
     },
     "node_modules/leven": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "test": "npx jest"
   },
   "dependencies": {
-    "leader-line": "^1.0.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "sweetalert2": "^11.4.8",


### PR DESCRIPTION
hopefully, should prevent the CI node 14.x from crashing as well